### PR TITLE
Fix tree printing error for labels with ANSI codes

### DIFF
--- a/src/main/java/tech/vanyo/treePrinter/TreePrinter.java
+++ b/src/main/java/tech/vanyo/treePrinter/TreePrinter.java
@@ -149,9 +149,12 @@ public class TreePrinter<T> {
 
             List<TreeLine> allTreeLines = new ArrayList<>();
 
+            // strip ANSI escape codes to get length of rendered string. Fixes wrong padding when labels use ANSI escapes for colored nodes.
+            String renderedRootLabel = rootLabel.replaceAll("\\e\\[[\\d;]*[^\\d;]", "");
+
             // add the root and the two branches leading to the subtrees
 
-            allTreeLines.add(new TreeLine(rootLabel, -(rootLabel.length() - 1) / 2, rootLabel.length() / 2));
+            allTreeLines.add(new TreeLine(rootLabel, -(renderedRootLabel.length() - 1) / 2, renderedRootLabel.length() / 2));
 
             // also calculate offset adjustments for left and right subtrees
             int leftTreeAdjust = 0;


### PR DESCRIPTION
When using labels containing ANSI escape codes - for example label `\u001b[31mTEST\u001b[0m` (red label TEST rendered in terminal) the length of label evaluates to 13 instead of 4, because escaping ANSI is an internal mechanism of the terminal. This patch assumes that escape sequences shouldn't be visible anyway, so we strip them always without asking.